### PR TITLE
reduce scope of bug reproducibility

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PoolboyError.MixProject do
     [
       app: :poolboy_error,
       version: "0.1.0",
-      elixir: "~> 1.7-dev",
+      elixir: "~> 1.6.5",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]


### PR DESCRIPTION
mix -> rebar3 compilation bug is exhibited using Elixir 1.6.5 - as this is an easier version to get running it's better for this example.